### PR TITLE
Correction pour tous les maires?!

### DIFF
--- a/script.js
+++ b/script.js
@@ -180,7 +180,7 @@ $(async function () {
 
         perCandidate[n.Candidat].total++
         perCandidate[n.Candidat].data[deptToCodeMap[n.Departement]]++
-        if (n.Mandat === "Maire") {
+        if (n.Mandat.includes("Maire")) {
             perCandidate[n.Candidat].dataMayor[deptToCodeMap[n.Departement]]++
         }
         if (!deptToCodeMap[n.Departement]) {


### PR DESCRIPTION
Pas sûr de la correction pas pour des raisons techniques.

Cela dépend de la règle institutionnelle: pour les règles, les Maires sont-ils assimilés aux autres Maires que sont `Maire d'arrondissement`, `Maire délégué d'une commune associée ou d'une commune déléguée`, `Maire déléguée d'une commune associée ou d'une commune déléguée`?

Question déduite de cet appel `jq -r '[.[].Mandat] | sort| unique | .[]' data2.json` qui retourne

```
Conseiller de Paris
Conseiller départemental
Conseiller métropolitain de Lyon
Conseiller régional
Conseiller à l'Assemblée des Français de l'étranger
Conseillère de Paris
Conseillère départementale
Conseillère métropolitaine de Lyon
Conseillère régionale
Conseillère à l'Assemblée des Français de l'étranger
Député
Députée
Maire
Maire d'arrondissement
Maire délégué d'une commune associée ou d'une commune déléguée
Maire déléguée d'une commune associée ou d'une commune déléguée
Membre d'une assemblée d'une collectivité territoriale d'outre-mer à statut particulier
Membre de l'Assemblée de Corse
Président d'un EPCI à fiscalité propre
Président du conseil consulaire
Présidente d'un EPCI à fiscalité propre
Présidente du conseil consulaire
Représentant français au Parlement européen
Représentante française au Parlement européen
Sénateur
Sénatrice
```